### PR TITLE
feat: AC Error logs

### DIFF
--- a/src/ac_tool/error_log.py
+++ b/src/ac_tool/error_log.py
@@ -1,0 +1,29 @@
+import os
+import datetime
+
+def create_log_file(dir):
+    fileName = "subtopology-logs-" + datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S") + ".txt"
+    
+    try:
+        # create filename
+        os.makedirs(dir, exist_ok=True)
+        with open(os.path.join(dir, fileName), "w") as f:
+            f.write("== Subtopology Autocoder logs ==\n\n")
+    except FileExistsError:
+        # directory already exists
+        pass
+    except Exception as e:
+        print(f"Error creating log file: {e}")
+        return None
+    
+    pathToFile = os.path.join(dir, fileName)
+    return pathToFile
+
+def logOK(logFile, message):
+    with open(logFile, "a") as f:
+        f.write(f"[✓] {message}\n")
+        
+def logERR(logFile, message):
+    with open(logFile, "a") as f:
+        f.write(f"[x] {message}\n")
+

--- a/src/ac_tool/tool.py
+++ b/src/ac_tool/tool.py
@@ -497,6 +497,13 @@ def main():
         help="bypasses dependency management for testing",
         action=argparse.BooleanOptionalAction,
     )
+    
+    parser.add_argument(
+        "--r",
+        "--root",
+        help="path to root directory",
+        required=False,
+    )
 
     parsed, _ = parser.parse_known_args()
 
@@ -505,12 +512,14 @@ def main():
     global FPP_CACHE
     global FPP_INPUT
     global IN_TEST
+    global FPRIME_ROOT
 
     FPP_LOCS = parsed.locs
     FPP_OUTPUT = parsed.p
     FPP_CACHE = parsed.c
     FPP_INPUT = parsed.f
     IN_TEST = parsed.t or False
+    FPRIME_ROOT = parsed.r or False
 
     if not os.path.isabs(FPP_LOCS):
         FPP_LOCS = Path(FPP_LOCS).resolve()

--- a/src/cmake/autocoder/subtopology.cmake
+++ b/src/cmake/autocoder/subtopology.cmake
@@ -18,11 +18,11 @@ function(subtopology_setup_autocode AC_INPUT_FILE)
     set(GENERATED_FILES "${CMAKE_CURRENT_BINARY_DIR}/ST/${FPRIME_CURRENT_MODULE}.subtopologies.fpp" "${CMAKE_CURRENT_BINARY_DIR}/ST/st-locs.fpp" "${CMAKE_CURRENT_BINARY_DIR}/${BASENAME}")
 
     if (CMAKE_DEBUG_OUTPUT)
-        message(STATUS "[Subtopology Ac] CLI: ${PYTHON} ${PYTHON_TOOL} --locs ${CMAKE_BINARY_DIR}/locs.fpp --file ${AC_INPUT_FILE} --p ${OUTPUT_FILE} --c ${LOCAL_CACHE}")
+        message(STATUS "[Subtopology Ac] CLI: ${PYTHON} ${PYTHON_TOOL} --locs ${CMAKE_BINARY_DIR}/locs.fpp --file ${AC_INPUT_FILE} --p ${OUTPUT_FILE} --c ${LOCAL_CACHE} --r ${FPRIME_PROJECT_ROOT}")
     endif()
 
     execute_process(
-        COMMAND ${PYTHON} ${PYTHON_TOOL} --locs ${CMAKE_BINARY_DIR}/locs.fpp --file ${AC_INPUT_FILE} --p ${OUTPUT_FILE} --c ${LOCAL_CACHE}
+        COMMAND ${PYTHON} ${PYTHON_TOOL} --locs ${CMAKE_BINARY_DIR}/locs.fpp --file ${AC_INPUT_FILE} --p ${OUTPUT_FILE} --c ${LOCAL_CACHE} --r ${FPRIME_PROJECT_ROOT}
         RESULT_VARIABLE RETURN_CODE
     )
     


### PR DESCRIPTION
Error logs from the autocoder are in the quite difficult to read `generate` stdout. Instead, a log file should be created that holds all of the prints from the autocoder during the generate step.